### PR TITLE
Adding new entries for TIS examinee attribute rules with correct fiel…

### DIFF
--- a/TDSQAService/OSS.TIS/SQL/TISDB/5_Update_ICA_Attributes_Typo.sql
+++ b/TDSQAService/OSS.TIS/SQL/TISDB/5_Update_ICA_Attributes_Typo.sql
@@ -1,0 +1,6 @@
+-- Fixes typos for RTSAttribute fieldname from "EnglishLanguageProficiencLevel" to "EnglishLanguageProficiencyLevel"
+INSERT [dbo].[RTSAttributes] ([_fk_ProjectID], [GroupName], [Context], [ContextDate], [Decrypt], [XMLName], [EntityType], [Relationship], [FieldName], [FetchIfNotInXml]) VALUES (13, N'DW2', N'INITIAL', NULL, 0, N'EnglishLanguageProficiencyLevel', N'', N'', N'EnglishLanguageProficiencyLevel', 0)
+INSERT [dbo].[RTSAttributes] ([_fk_ProjectID], [GroupName], [Context], [ContextDate], [Decrypt], [XMLName], [EntityType], [Relationship], [FieldName], [FetchIfNotInXml]) VALUES (13, N'DW2', N'FINAL', NULL, 0, N'EnglishLanguageProficiencyLevel', N'', N'', N'EnglishLanguageProficiencyLevel', 0)
+INSERT [dbo].[RTSAttributes] ([_fk_ProjectID], [GroupName], [Context], [ContextDate], [Decrypt], [XMLName], [EntityType], [Relationship], [FieldName], [FetchIfNotInXml]) VALUES (15, N'DW2', N'INITIAL', NULL, 0, N'EnglishLanguageProficiencyLevel', N'', N'', N'EnglishLanguageProficiencyLevel', 0)
+INSERT [dbo].[RTSAttributes] ([_fk_ProjectID], [GroupName], [Context], [ContextDate], [Decrypt], [XMLName], [EntityType], [Relationship], [FieldName], [FetchIfNotInXml]) VALUES (15, N'DW2', N'FINAL', NULL, 0, N'EnglishLanguageProficiencyLevel', N'', N'', N'EnglishLanguageProficiencyLevel', 0)
+


### PR DESCRIPTION
https://jira.fairwaytech.com/browse/TDS-1124

Adding a new seed script to insert records with TIS attribute/relationship forwarding rules. These rules are used to configure TIS to not send PII through to RDW. I am leaving the existing records (with the typo) intact for back-wards compatibility purpose, as @jtreuting has suggested.