### PR TITLE
Fix scoring ICA assessments

### DIFF
--- a/TDSQAService/OSS.TIS/SQL/TISDB/6_Update_StoredProcedures_Remove_OppId.sql
+++ b/TDSQAService/OSS.TIS/SQL/TISDB/6_Update_StoredProcedures_Remove_OppId.sql
@@ -82,7 +82,10 @@ AS
 BEGIN
     
     DECLARE @nextOppId VARCHAR(50)
-    SELECT @nextOppId = CAST(MAX(OppId)+1 as varchar(50)) FROM XMLRepository WHERE OppId < 5000000
+    IF @OppId = 0 
+        SELECT @nextOppId = CAST(MAX(CAST(OppId as int))+1 as varchar(50)) FROM XMLRepository WHERE OppId < 5000000
+    ELSE
+        @nextOppId = @OppId
 
     INSERT INTO XMLRepository
            ([Location]


### PR DESCRIPTION
OppId input parameter was being ignored and a value for OppId was being generated instead when adding a row to XMLRepository database.
This is due to TDS sending a zero value for the OppId in the TRT.  TIS was expecting a value OppId value.
This change detects if a zero value for OppId is being sent and generate a valid OppId.
Otherwise, the OppId being passed in is used.
This is important for ICA assessments, since a new, virtual exam is created and the OppId created and set in a different table (CombinationTestOpportunity).