### PR TITLE
fixed error on TIS windows service startup

### DIFF
--- a/Common/TDSQASystemAPI/BL/testpackage/administration/ItembankAdministrationDataService.cs
+++ b/Common/TDSQASystemAPI/BL/testpackage/administration/ItembankAdministrationDataService.cs
@@ -195,15 +195,19 @@ namespace TDSQASystemAPI.BL.testpackage.administration
                                     {
                                         ItemKey = item.Key,
                                         DimensionKey = dimensionDto.ItemScoreDimensionKey,
-                                        MeasurementModelKey = dimensionDto.MeasurementModel
+                                        MeasurementModelKey = dimensionDto.MeasurementModel,
+                                        Dimension = dimensionDto.Dimension
                                     };
 
 
             var itemMeasurementParameters = from item in allItems
                                             from dimension in item.ItemScoreDimensions
                                             from param in dimension.ItemScoreParameter
-                                            join dimensionDto in scoreDimensionMap
-                                                on item.Key equals dimensionDto.ItemKey
+                                            from dimensionDto in scoreDimensionMap
+                                            where item.Key == dimensionDto.ItemKey && 
+                                            (                                                
+                                                (dimension.dimension?.ToString() ?? "").Equals(dimensionDto.Dimension)
+                                            )
                                             select new ItemMeasurementParameterDTO
                                             {
                                                 ItemScoreDimensionKey = dimensionDto.DimensionKey,


### PR DESCRIPTION
When ICA assessments with multiple segments are loaded in the new assessment format, the TIS windows service does not start.
The error message given:  "The GPC model must have one more parameter than score points but this item has scorePoints = 2 and 5 parameters"
This is due to too many rows added to the ItemMeasurementParameter table when an item has a dimension.
Adding filtering to the number item measurement parameters based on the parameter dimension field.